### PR TITLE
Fix some warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+CFLAGS=-g -std=c89 -Wall -pedantic -Wextra
+
 all: url_parser.c main.c
-	clang -g --std=c89 url_parser.c main.c -o url_parse_test
+	$(CC) $(CFLAGS) url_parser.c main.c -o url_parse_test
 

--- a/main.c
+++ b/main.c
@@ -5,8 +5,6 @@
 
 int main() {
 
-    char buf[1024];
-
     struct http_parser_url parse_info;
     const char *url = "ws://debug.example.com:123/my/path";
 
@@ -14,9 +12,8 @@ int main() {
 
 #define PRINT(field) \
     do { \
-        snprintf(buf, parse_info.field_data[field].len + 1, "%s", \
-                &url[parse_info.field_data[field].off]); \
-        printf( #field ": %s\n", buf); \
+        printf( #field ": %*s\n", parse_info.field_data[field].len, \
+                &url[parse_info.field_data[field].off]);            \
     } while (0)
 
     printf("port: %d\n", parse_info.port);

--- a/url_parser.c
+++ b/url_parser.c
@@ -450,11 +450,12 @@ http_parse_host_char(enum http_host_state s, const char ch) {
 
 static int
 http_parse_host(const char * buf, struct http_parser_url *u, int found_at) {
-  assert(u->field_set & (1 << UF_HOST));
   enum http_host_state s;
 
   const char *p;
   size_t buflen = u->field_data[UF_HOST].off + u->field_data[UF_HOST].len;
+
+  assert(u->field_set & (1 << UF_HOST));
 
   u->field_data[UF_HOST].len = 0;
 
@@ -566,7 +567,7 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
       case s_req_server_with_at:
         found_at = 1;
 
-      /* FALLTROUGH */
+      /* FALLTHROUGH */
       case s_req_server:
         uf = UF_HOST;
         break;


### PR DESCRIPTION
Hi! Thanks for providing this extracted url-parser repo, now that http_parser https://github.com/nodejs/http-parser is not being maintained anymore. This is an excellent URL parser lib which doesn't do any allocations.

I wonder if this repo is active, since there is no activity for the last 8 years, but OTOH, there are practically no upstream changes to the URL parser part during this time either.

Now, I fixed some warnings I got when compiling with -std=c89 and all warnings enabled:

* snprintf is not defined in C89 (in test code main.c)
* mixing declarations and code is not allowed in C89 (url_parser.c) -- the same fix as done in https://github.com/nodejs/http-parser/blob/main/http_parser.c#L2336
* implicit fallthrough warning (not related to C89) due to misspelled FALLTHROUGH comment (GCC -Wimplicit-fallthrough)

These are shown when compiling with `-Wall -Wextra -pedantic -std=c89` with GCC (all three warnings) and clang (the two first).

We don't really need C89 but the original project claimed to be written in C89, so better follow that because we can.

Additionally change Makefile to use variables so the options can be passed to make. Compile with warnings by default.